### PR TITLE
Unescape slash instead of unicode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ MoceanAPI Client Library for PHP
 [![License](https://img.shields.io/packagist/l/mocean/client.svg)](https://packagist.org/packages/mocean/client)
 [![Total Downloads](https://img.shields.io/packagist/dt/mocean/client.svg)](https://packagist.org/packages/mocean/client)
 
-*This library requires a minimum PHP version of 5.5*
+*This library requires a minimum PHP version of 7.3*
 
 This is the PHP client library for use Mocean's API. To use this, you'll need a Mocean account. Sign up [for free at 
 moceanapi.com][signup].

--- a/src/Voice/Voice.php
+++ b/src/Voice/Voice.php
@@ -77,11 +77,11 @@ class Voice implements ModelInterface, AsRequest, AsResponse
     public function setMoceanCommand($moceanCommand)
     {
         if ($moceanCommand instanceof McBuilder) {
-            $this->requestData['mocean-command'] = json_encode($moceanCommand->build(), JSON_UNESCAPED_UNICODE);
+            $this->requestData['mocean-command'] = json_encode($moceanCommand->build(), JSON_UNESCAPED_SLASHES);
         } elseif ($moceanCommand instanceof AbstractMc) {
-            $this->requestData['mocean-command'] = json_encode([$moceanCommand->getRequestData()], JSON_UNESCAPED_UNICODE);
+            $this->requestData['mocean-command'] = json_encode([$moceanCommand->getRequestData()], JSON_UNESCAPED_SLASHES);
         } elseif (is_array($moceanCommand)) {
-            $this->requestData['mocean-command'] = json_encode($moceanCommand, JSON_UNESCAPED_UNICODE);
+            $this->requestData['mocean-command'] = json_encode($moceanCommand, JSON_UNESCAPED_SLASHES);
         } else {
             $this->requestData['mocean-command'] = $moceanCommand;
         }

--- a/test/Voice/VoiceTest.php
+++ b/test/Voice/VoiceTest.php
@@ -91,16 +91,16 @@ class VoiceTest extends AbstractTesting
             ],
         ];
         $voice = new \Mocean\Voice\Voice('testing to', $mc);
-        $this->assertEquals($voice->getRequestData()['mocean-command'], json_encode($mc));
+        $this->assertEquals($voice->getRequestData()['mocean-command'], json_encode($mc,JSON_UNESCAPED_SLASHES));
 
         $mcBuilder = new McBuilder();
         $mcBuilder->add(Mc::play()->setFiles($mc[0]['file']));
         $voice->setMoceanCommand($mcBuilder);
-        $this->assertEquals($voice->getRequestData()['mocean-command'], json_encode($mc));
+        $this->assertEquals($voice->getRequestData()['mocean-command'], json_encode($mc,JSON_UNESCAPED_SLASHES));
 
         $playMc = Mc::play()->setFiles($mc[0]['file']);
         $voice->setMoceanCommand($playMc);
-        $this->assertEquals($voice->getRequestData()['mocean-command'], json_encode($mc));
+        $this->assertEquals($voice->getRequestData()['mocean-command'], json_encode($mc,JSON_UNESCAPED_SLASHES));
     }
 
     private function objectTesting($res)


### PR DESCRIPTION
Temporary fix for voice API backend not handling `\/` gracefully, which causes URL in `play` action not getting recognised and not played